### PR TITLE
Fixes query_channel_range remote overflow problem

### DIFF
--- a/packages/lntools-wire/__tests__/gossip/peer-gossip-synchronizer.spec.ts
+++ b/packages/lntools-wire/__tests__/gossip/peer-gossip-synchronizer.spec.ts
@@ -26,6 +26,7 @@ describe("PeerGossipSynchronizer", () => {
   type QueryEventAssertions = {
     onSyncRange_WithDefaults: () => void;
     onSyncRange_WithOptions: () => void;
+    onSyncRange_WithOverflow: () => void;
     onReplyChannelRange_Complete_NoScids: () => void;
     onReplyChannelRange_Complete_Scids: () => void;
     onReplyChannelRange_NotComplete_Scids: () => void;
@@ -49,6 +50,13 @@ describe("PeerGossipSynchronizer", () => {
         sut.syncRange(1000000, 1000);
       });
       assertions.onSyncRange_WithOptions();
+    });
+
+    describe("event: call .syncRange() with overflow", () => {
+      beforeEach(() => {
+        sut.syncRange(1000);
+      });
+      assertions.onSyncRange_WithOverflow();
     });
 
     describe("event: receive reply_channel_range complete=true, with_scids=true", () => {
@@ -157,6 +165,18 @@ describe("PeerGossipSynchronizer", () => {
         });
       },
 
+      onSyncRange_WithOverflow: () => {
+        it("should send query_channel_range", () => {
+          const msg = peer.sendMessage.args[0][0] as QueryChannelRangeMessage;
+          expect(msg.firstBlocknum).to.equal(1000);
+          expect(msg.numberOfBlocks).to.equal(4294967295 - 1000);
+        });
+
+        it("should transition to awaiting_ranges", () => {
+          expect(sut.queryState).to.equal(PeerGossipQueryState.AwaitingRanges);
+        });
+      },
+
       onReplyChannelRange_Complete_NoScids: () => {
         it("should not send anything", () => {
           expect(peer.sendMessage.callCount).to.equal(0);
@@ -253,7 +273,12 @@ describe("PeerGossipSynchronizer", () => {
         // TODO
         it("to be defined");
       },
+
       onSyncRange_WithOptions: () => {
+        it("to be defined");
+      },
+
+      onSyncRange_WithOverflow: () => {
         it("to be defined");
       },
 
@@ -363,6 +388,11 @@ describe("PeerGossipSynchronizer", () => {
       },
 
       onSyncRange_WithOptions: () => {
+        // TODO
+        it("to be defined");
+      },
+
+      onSyncRange_WithOverflow: () => {
         // TODO
         it("to be defined");
       },

--- a/packages/lntools-wire/lib/gossip/peer-gossip-synchronizer.ts
+++ b/packages/lntools-wire/lib/gossip/peer-gossip-synchronizer.ts
@@ -94,7 +94,7 @@ export class PeerGossipSynchronizer extends EventEmitter {
     this.receiveState = PeerGossipReceiveState.Inactive;
   }
 
-  public activate(start: number = Math.trunc(Date.now() / 1000), range: number = 4294967295) {
+  public activate(start: number = Math.trunc(Date.now() / 1000), range = 4294967295) {
     const gossipFilter = new GossipTimestampFilterMessage();
     gossipFilter.chainHash = this.chainHash;
     gossipFilter.firstTimestamp = start;
@@ -103,12 +103,8 @@ export class PeerGossipSynchronizer extends EventEmitter {
     this.receiveState = PeerGossipReceiveState.Active;
   }
 
-  public syncRange(firstBlocknum: number = 0, numberOfBlocks = 4294967295) {
-    this.logger.info(
-      "synchronizing from block %d to %d",
-      firstBlocknum,
-      firstBlocknum + numberOfBlocks,
-    );
+  public syncRange(firstBlocknum: number = 0, numberOfBlocks = 4294967295 - firstBlocknum) {
+    this.logger.info("synchronizing from block %d to %d", firstBlocknum, numberOfBlocks);
     const queryRangeMessage = new QueryChannelRangeMessage();
     queryRangeMessage.chainHash = this.chainHash;
     queryRangeMessage.firstBlocknum = firstBlocknum;

--- a/packages/lntools-wire/package-lock.json
+++ b/packages/lntools-wire/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lntools/wire",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/lntools-wire/package.json
+++ b/packages/lntools-wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lntools/wire",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Lightning Network Wire Protocol",
   "scripts": {
     "test": "../../node_modules/.bin/nyc --reporter=lcov --reporter=text --extension=.ts ../../node_modules/.bin/mocha --require ts-node/register --recursive \"__tests__/**/*.spec.*\"",


### PR DESCRIPTION
Fixes #41 

This change modifies the `PeerGossipSynchronizer` to subtract the start block number from uint32 max value.  

This change max be reverted once all peers correctly handle sending of data.