### PR TITLE
graph-example: periodically persist graph to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ test.json
 
 config.json
 .db
+graph.json


### PR DESCRIPTION
This change persists the in-memory graph into the file system under graph.json.
The file graph.json is also added to the .gitignore file

Closes #53 