### PR TITLE
wire: gossip_manager tracks last seen block

### DIFF
--- a/examples/gossip/index.ts
+++ b/examples/gossip/index.ts
@@ -1,0 +1,114 @@
+import { ConsoleTransport, Logger, LogLevel } from "@lntools/logger";
+import { ChannelAnnouncementMessage } from "@lntools/wire";
+import { InitMessage } from "@lntools/wire";
+import { ChannelUpdateMessage } from "@lntools/wire";
+import { NodeAnnouncementMessage } from "@lntools/wire";
+import { ExtendedChannelAnnouncementMessage } from "@lntools/wire";
+import { Peer } from "@lntools/wire";
+import { GossipMemoryStore } from "@lntools/wire";
+import { GossipManager } from "@lntools/wire";
+
+// tslint:disable-next-line: no-var-requires
+const config = require("./config.json");
+
+const logger = new Logger("app");
+logger.transports.push(new ConsoleTransport(console));
+logger.level = LogLevel.Debug;
+
+async function connectToPeer(peerInfo: { rpk: string; host: string; port: number }) {
+  // local secret is obtained from the config file and
+  // should be a 32-byte hex encoded ECDSA private key
+  const ls = Buffer.from(config.key, "hex");
+
+  // chainHash from the config, this should be the chainhash for testnet
+  const chainHash = Buffer.from(config.chainhash, "hex");
+
+  // constructs the gossip data storage and the manager for
+  // controlling gossip requests with the peer.
+  const gossipStore = new GossipMemoryStore();
+  const pendingStore = new GossipMemoryStore();
+  const gossipManager = new GossipManager({
+    chainHash,
+    logger,
+    gossipStore,
+    pendingStore,
+  });
+
+  // attach error handling for gossip manager
+  gossipManager.on("error", err => logger.error("gossip failed", err));
+
+  // attach a message handler for completed and validated messages
+  let counter = 0;
+  gossipManager.on("message", msg => {
+    let extra = "";
+    if (msg instanceof ChannelAnnouncementMessage) {
+      extra += msg.shortChannelId.toString();
+      extra += " ";
+    }
+    if (msg instanceof ExtendedChannelAnnouncementMessage) {
+      extra += msg.outpoint.toString();
+    }
+    if (msg instanceof ChannelUpdateMessage) {
+      extra += msg.shortChannelId.toString();
+      extra += " ";
+      extra += msg.direction;
+    }
+    if (msg instanceof NodeAnnouncementMessage) {
+      extra += msg.nodeId.toString("hex");
+    }
+
+    logger.info("msg: %d, type: %d %s %s", ++counter, msg.type, msg.constructor.name, extra);
+  });
+
+  // start the gossip manager to enable us to add peers to it
+  await gossipManager.start();
+
+  // constructs an init message to signal to the remote
+  // peer the capabilities of the current node. This
+  // method is called by the peer when a valid noise
+  // connection has been established.
+  const initMessageFactory = () => {
+    const initMessage = new InitMessage();
+    initMessage.localInitialRoutingSync = false;
+    initMessage.localDataLossProtect = true;
+    initMessage.localGossipQueries = true;
+    initMessage.localGossipQueriesEx = false;
+    return initMessage;
+  };
+
+  // constructs the peer and attaches a logger for tthe peer.
+  const peer = new Peer({
+    ls,
+    rpk: Buffer.from(peerInfo.rpk, "hex"),
+    host: peerInfo.host,
+    port: peerInfo.port,
+    logger,
+    initMessageFactory,
+  });
+  peer.on("open", () => logger.info("connecting"));
+  peer.on("error", err => logger.error("%s", err.stack));
+  peer.on("ready", () => logger.info("peer is ready"));
+
+  // adds the peer to the gossip mananger. Once the peer is
+  // connected the gossip manager will take efforts to
+  // synchronize information with the remote peer.
+  gossipManager.addPeer(peer);
+
+  // connect to the remote peer using the local secret provided
+  // in our config file
+  peer.connect();
+
+  // peer.on("close", () => {
+  //   logger.warn("disconnected, reconnecting...");
+  //   setTimeout(() => peer.connect(), 15000);
+  // });
+}
+
+connectToPeer(config.peers[0])
+  .then(() => {
+    process.stdin.resume();
+  })
+  .catch(err => {
+    logger.error(err);
+    process.exit(1);
+  });

--- a/examples/gossip/package.json
+++ b/examples/gossip/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "example-gossip",
+  "version": "1.0.0",
+  "description": "Gossip example",
+  "scripts": {
+    "start": "../../node_modules/.bin/ts-node index.ts"
+  },
+  "keywords": [],
+  "author": "Brian Mancini <bmancini@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "@lntools/buffer-cursor": "file:../../packages/lntools-buffer-cursor",
+    "@lntools/chainmon": "file:../../packages/lntools-chainmon",
+    "@lntools/crypto": "file:../../packages/lntools-crypto",
+    "@lntools/logger": "file:../../packages/lntools-logger",
+    "@lntools/noise": "file:../../packages/lntools-noise",
+    "@lntools/wire": "file:/../../packages/lntools-wire"
+  }
+}


### PR DESCRIPTION
Closes #62 

This commit fixes the gossip_manager so that it will correctly fetch missing
data from a peer when a reconnection event occurs. Prior to this commit it
would use the block height obtained during the initial sync with the peer.

This commit modifies the gossip_manager to perform two actions:

1. It now tracks the highest chan_ann messages block height
2. It corrects an issue where subsequent reconnection events triggered a sync
   based on the originating (closure scoped) block height that was obtained
   from the gossip store.