### PR TITLE
graph: adding remove channel to graph_manager

### DIFF
--- a/packages/lntools-graph/__tests__/graph-manager.spec.ts
+++ b/packages/lntools-graph/__tests__/graph-manager.spec.ts
@@ -1,5 +1,6 @@
 // tslint:disable: no-unused-expression
-import { AddressIPv4, Bitmask, ShortChannelId } from "@lntools/wire";
+import { AddressIPv4, Bitmask, OutPoint, ShortChannelId } from "@lntools/wire";
+import { ExtendedChannelAnnouncementMessage } from "@lntools/wire";
 import { IGossipEmitter } from "@lntools/wire";
 import { ChannelAnnouncementMessage } from "@lntools/wire";
 import { ChannelUpdateMessage } from "@lntools/wire";
@@ -177,6 +178,26 @@ describe("GraphManager", () => {
       msg.features = new Bitmask(BigInt(2));
       msg.addresses = [new AddressIPv4("1.1.1.1", 9735)];
       gossipEmitter.emit("message", msg);
+    });
+  });
+
+  describe("close channel", () => {
+    function createMsg() {
+      const msg = new ExtendedChannelAnnouncementMessage();
+      msg.shortChannelId = scid;
+      msg.outpoint = new OutPoint("1111111111111111111111111111111111111111111111111111111111111111", 0); // prettier-ignore
+      msg.capacity = BigInt(1000);
+      msg.nodeId1 = node1;
+      msg.nodeId2 = node2;
+      msg.features = new Bitmask();
+      return msg;
+    }
+
+    it("should remove a channel from the graph", () => {
+      gossipEmitter.emit("message", createMsg());
+      expect(sut.graph.channels.size).to.equal(1);
+      sut.removeChannel(new OutPoint("1111111111111111111111111111111111111111111111111111111111111111", 0)); // prettier-ignore
+      expect(sut.graph.channels.size).to.equal(0);
     });
   });
 });

--- a/packages/lntools-graph/lib/graph-manager.ts
+++ b/packages/lntools-graph/lib/graph-manager.ts
@@ -1,4 +1,4 @@
-import { IGossipEmitter, IWireMessage } from "@lntools/wire";
+import { IGossipEmitter, IWireMessage, OutPoint } from "@lntools/wire";
 import { ChannelAnnouncementMessage } from "@lntools/wire";
 import { ChannelUpdateMessage } from "@lntools/wire";
 import { NodeAnnouncementMessage } from "@lntools/wire";
@@ -34,6 +34,21 @@ export class GraphManager extends EventEmitter {
     this.graph = graph;
     this.gossipEmitter = gossipManager;
     this.gossipEmitter.on("message", this._onMessage.bind(this));
+  }
+
+  /**
+   * Closes channel via the outpoint
+   * @param outpoint
+   */
+  public removeChannel(outpoint: OutPoint) {
+    const outpointStr = outpoint.toString();
+    for (const channel of this.graph.channels.values()) {
+      if (outpointStr === channel.channelPoint.toString()) {
+        this.graph.removeChannel(channel);
+        this.emit("channel_closed", channel);
+        return;
+      }
+    }
   }
 
   private _onMessage(msg: IWireMessage) {

--- a/packages/lntools-graph/lib/graph.ts
+++ b/packages/lntools-graph/lib/graph.ts
@@ -67,7 +67,7 @@ export class Graph {
   /**
    * Removes the node from the graph
    */
-  public removeChannel(channel) {
+  public removeChannel(channel: Channel) {
     const key = channel.shortChannelId.toNumber();
     const n1 = this.getNode(channel.nodeId1);
     const n2 = this.getNode(channel.nodeId2);


### PR DESCRIPTION
Adding a remove channel by outpoint method. This method can be used when
a transaction watcher finds a spent outpoint that needs to be removed from
the graph.

Closes #67 