### PR TITLE
Wait for bitcoind sync to complete

### DIFF
--- a/packages/lntools-bitcoind/lib/wait.ts
+++ b/packages/lntools-bitcoind/lib/wait.ts
@@ -1,0 +1,3 @@
+export function wait(ms: number): Promise<any> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/lntools-wire/__tests__/gossip/gossip-filter.spec.ts
+++ b/packages/lntools-wire/__tests__/gossip/gossip-filter.spec.ts
@@ -30,6 +30,10 @@ class FakeChainClient implements IGossipFilterChainClient {
   public getUtxo(txId: string, voutIdx: number): Promise<HasScriptPubKey & HasValue> {
     throw new Error("");
   }
+
+  public async waitForSync(): Promise<boolean> {
+    return true;
+  }
 }
 
 describe("GossipFilter", () => {

--- a/packages/lntools-wire/lib/gossip/gossip-filter-chain-client.ts
+++ b/packages/lntools-wire/lib/gossip/gossip-filter-chain-client.ts
@@ -9,6 +9,7 @@ export interface IGossipFilterChainClient {
   getBlockHash(height: number): Promise<string>;
   getBlock(hash: string): Promise<HasTxStrings>;
   getUtxo(txId: string, voutIdx: number): Promise<HasScriptPubKey & HasValue>;
+  waitForSync(): Promise<boolean>;
 }
 
 export type HasTxStrings = {

--- a/packages/lntools-wire/lib/gossip/gossip-manager.ts
+++ b/packages/lntools-wire/lib/gossip/gossip-manager.ts
@@ -90,6 +90,14 @@ export class GossipManager extends EventEmitter {
    */
   public async start() {
     this.logger.info("starting gossip manager");
+
+    // wait for chain sync to complete
+    if (this._chainClient) {
+      this.logger.info("waiting for chain sync");
+      await this._chainClient.waitForSync();
+      this.logger.info("chain sync complete");
+    }
+
     await this._restoreState();
 
     // emit all restored messages


### PR DESCRIPTION
This adds a new method to bitcoind client to wait for the chain sync to complete.
This method is added to wire/gossip-manager to prevent the gossip sync from starting until the chain client has successfully synced.

This PR closes #37 

