### PR TITLE
Starting refactor for multi-strategy gossip 

### DIFF
--- a/packages/lntools-wire/__tests__/gossip/peer-gossip-receiver.spec.ts
+++ b/packages/lntools-wire/__tests__/gossip/peer-gossip-receiver.spec.ts
@@ -1,0 +1,96 @@
+// tslint:disable: no-unused-expression
+
+import { ILogger } from "@lntools/logger";
+import { expect } from "chai";
+import sinon from "sinon";
+import { PeerGossipReceiver } from "../../lib/gossip/peer-gossip-receiver";
+import { PeerGossipSynchronizer } from "../../lib/gossip/peer-gossip-synchronizer";
+import { GossipTimestampFilterMessage } from "../../lib/messages/gossip-timestamp-filter-message";
+import { QueryChannelRangeMessage } from "../../lib/messages/query-channel-range-message";
+import { QueryShortChannelIdsMessage } from "../../lib/messages/query-short-channel-ids-message";
+import { ReplyChannelRangeMessage } from "../../lib/messages/reply-channel-range-message";
+import { ReplyShortChannelIdsEndMessage } from "../../lib/messages/reply-short-channel-ids-end-message";
+import { IWireMessage } from "../../lib/messages/wire-message";
+import { ShortChannelId } from "../../lib/shortchanid";
+import { createFakeLogger, createFakePeer } from "../_test-utils";
+import { PeerGossipReceiveState } from "../../lib/gossip/peer-gossip-receive-state";
+
+describe("PeerGossipSynchronizer", () => {
+  let chainHash: Buffer;
+  let sut: PeerGossipReceiver;
+  let peer: any;
+  let logger: ILogger;
+
+  beforeEach(() => {
+    chainHash = Buffer.alloc(32, 1);
+    peer = createFakePeer();
+    logger = createFakeLogger();
+    sut = new PeerGossipReceiver(chainHash, peer, logger);
+  });
+
+  describe("initial state", () => {
+    it("in 'inactive' state", () => {
+      expect(sut.receiveState).to.equal(PeerGossipReceiveState.Inactive);
+    });
+
+    it("has uint32_max start", () => {
+      expect(sut.firstTimestamp).to.equal(4294967295);
+    });
+
+    it("has zero range", () => {
+      expect(sut.timestampRange).to.equal(0);
+    });
+  });
+
+  describe(".activate()", () => {
+    it("should send gossip_timestamp_filter", () => {
+      sut.activate(1590174550, 4294967294);
+      expect(peer.sendMessage.callCount).to.equal(1);
+
+      const msg: GossipTimestampFilterMessage = peer.sendMessage.args[0][0];
+      expect(msg.firstTimestamp).to.equal(1590174550);
+      expect(msg.timestampRange).to.equal(4294967294);
+    });
+
+    it("should transition state to 'receiving'", () => {
+      sut.activate(1590174550, 4294967294);
+      expect(sut.receiveState).to.equal(PeerGossipReceiveState.Receiving);
+    });
+
+    it("sets timestamp", () => {
+      sut.activate(1590174550, 4294967294);
+      expect(sut.firstTimestamp).to.equal(1590174550);
+    });
+
+    it("sets range", () => {
+      sut.activate(1590174550, 4294967294);
+      expect(sut.timestampRange).to.equal(4294967294);
+    });
+  });
+
+  describe(".deactivate()", () => {
+    it("should send gossip_timestamp_filter", () => {
+      sut.deactivate();
+      expect(peer.sendMessage.callCount).to.equal(1);
+
+      const msg: GossipTimestampFilterMessage = peer.sendMessage.args[0][0];
+      expect(msg.firstTimestamp).to.equal(4294967295);
+      expect(msg.timestampRange).to.equal(0);
+    });
+
+    it("should transition state to 'inactive'", () => {
+      sut.deactivate();
+      expect(sut.receiveState).to.equal(PeerGossipReceiveState.Inactive);
+    });
+
+    it("sets timestamp", () => {
+      sut.deactivate();
+      expect(sut.firstTimestamp).to.equal(4294967295);
+    });
+
+    it("sets range", () => {
+      sut.deactivate();
+      expect(sut.timestampRange).to.equal(0);
+    });
+  });
+});

--- a/packages/lntools-wire/__tests__/gossip/peer-gossip-receiver.spec.ts
+++ b/packages/lntools-wire/__tests__/gossip/peer-gossip-receiver.spec.ts
@@ -2,18 +2,10 @@
 
 import { ILogger } from "@lntools/logger";
 import { expect } from "chai";
-import sinon from "sinon";
-import { PeerGossipReceiver } from "../../lib/gossip/peer-gossip-receiver";
-import { PeerGossipSynchronizer } from "../../lib/gossip/peer-gossip-synchronizer";
-import { GossipTimestampFilterMessage } from "../../lib/messages/gossip-timestamp-filter-message";
-import { QueryChannelRangeMessage } from "../../lib/messages/query-channel-range-message";
-import { QueryShortChannelIdsMessage } from "../../lib/messages/query-short-channel-ids-message";
-import { ReplyChannelRangeMessage } from "../../lib/messages/reply-channel-range-message";
-import { ReplyShortChannelIdsEndMessage } from "../../lib/messages/reply-short-channel-ids-end-message";
-import { IWireMessage } from "../../lib/messages/wire-message";
-import { ShortChannelId } from "../../lib/shortchanid";
-import { createFakeLogger, createFakePeer } from "../_test-utils";
 import { PeerGossipReceiveState } from "../../lib/gossip/peer-gossip-receive-state";
+import { PeerGossipReceiver } from "../../lib/gossip/peer-gossip-receiver";
+import { GossipTimestampFilterMessage } from "../../lib/messages/gossip-timestamp-filter-message";
+import { createFakeLogger, createFakePeer } from "../_test-utils";
 
 describe("PeerGossipSynchronizer", () => {
   let chainHash: Buffer;

--- a/packages/lntools-wire/__tests__/gossip/peer-gossip-synchronizer.spec.ts
+++ b/packages/lntools-wire/__tests__/gossip/peer-gossip-synchronizer.spec.ts
@@ -14,6 +14,7 @@ import { ShortChannelId } from "../../lib/shortchanid";
 import { createFakeLogger, createFakePeer } from "../_test-utils";
 
 describe("PeerGossipSynchronizer", () => {
+  let chainHash: Buffer;
   let sut: PeerGossipSynchronizer;
   let peer: any;
   let logger: ILogger;
@@ -21,9 +22,10 @@ describe("PeerGossipSynchronizer", () => {
   let shortIdsQueryFailedEvent;
 
   beforeEach(() => {
+    chainHash = Buffer.alloc(32, 1);
     peer = createFakePeer();
     logger = createFakeLogger();
-    sut = new PeerGossipSynchronizer({ peer, chainHash: Buffer.alloc(32, 1), logger });
+    sut = new PeerGossipSynchronizer(chainHash, peer, logger);
 
     channelRangeFailedEvent = sinon.stub();
     sut.on("channel_range_failed", channelRangeFailedEvent);

--- a/packages/lntools-wire/lib/gossip/gossip-manager.ts
+++ b/packages/lntools-wire/lib/gossip/gossip-manager.ts
@@ -12,6 +12,7 @@ import { WireError, WireErrorCode } from "../wire-error";
 import { GossipFilter } from "./gossip-filter";
 import { IGossipFilterChainClient } from "./gossip-filter-chain-client";
 import { IGossipStore } from "./gossip-store";
+import { PeerGossipReceiver } from "./peer-gossip-receiver";
 import { PeerGossipSynchronizer } from "./peer-gossip-synchronizer";
 
 // tslint:disable-next-line: interface-name
@@ -121,29 +122,27 @@ export class GossipManager extends EventEmitter {
     peer.on("close", () => this.removePeer(peer));
 
     // construct a gossip synchronizer for the peer
-    const gossipSyncer = new PeerGossipSynchronizer({
+    const gossipSyncer = new PeerGossipSynchronizer(
+      this.chainHash,
       peer,
-      chainHash: this.chainHash,
-      logger: this.logger.sub("gossip_syncer", peer.id),
-    });
+      this.logger.sub("gossip_sync", peer.id),
+    );
     this._gossipSyncers.set(peer, gossipSyncer);
+
+    // construct a gossip receiver
+    const gossipReceiver = new PeerGossipReceiver(
+      this.chainHash,
+      peer,
+      this.logger.sub("gossip_rcvr", peer.id),
+    );
 
     // active gossip for the peer
     if (peer.state === PeerState.Ready) {
-      gossipSyncer.activate();
+      gossipReceiver.activate(); // enables gossip
+      gossipSyncer.queryRange(); // performs full historical sync
     } else {
-      peer.on("ready", () => gossipSyncer.activate());
-    }
-
-    // request historical sync
-    if (this._peers.size === 1) {
-      // handle reconnects
-      peer.on("ready", () => this._fullHistoricalSync(peer));
-
-      // if already ready then do a query range sync
-      if (peer.state === PeerState.Ready) {
-        this._fullHistoricalSync(peer);
-      }
+      peer.on("ready", () => gossipReceiver.activate());
+      peer.on("ready", () => gossipSyncer.queryRange());
     }
   }
 
@@ -231,12 +230,6 @@ export class GossipManager extends EventEmitter {
     for (const nodeAnn of nodeAnns) {
       if (!seenNodeIds.has(nodeAnn.nodeId.toString("hex"))) yield nodeAnn;
     }
-  }
-
-  private _fullHistoricalSync(peer: Peer) {
-    const firstBlock = 0; // always start at zero so we can get full updates
-    const gossipSyncer = this._gossipSyncers.get(peer);
-    gossipSyncer.queryRange(firstBlock);
   }
 
   private _onPeerMessage(msg: IWireMessage) {

--- a/packages/lntools-wire/lib/gossip/peer-gossip-receive-state.ts
+++ b/packages/lntools-wire/lib/gossip/peer-gossip-receive-state.ts
@@ -1,0 +1,4 @@
+export enum PeerGossipReceiveState {
+  Inactive = "inactive",
+  Receiving = "receiving",
+}

--- a/packages/lntools-wire/lib/gossip/peer-gossip-receiver.ts
+++ b/packages/lntools-wire/lib/gossip/peer-gossip-receiver.ts
@@ -1,0 +1,88 @@
+import { ILogger } from "@lntools/logger";
+import { GossipTimestampFilterMessage } from "../messages/gossip-timestamp-filter-message";
+import { IMessageSender } from "../peer";
+import { PeerGossipReceiveState } from "./peer-gossip-receive-state";
+
+const uint32max = 4294967295;
+
+/**
+ * This class is used to activate / deactivate receiving of gossip messages
+ * when the gossip_queries or gossip_queries_ex gossip sync strategies are used.
+ */
+export class PeerGossipReceiver {
+  private _receiveState: PeerGossipReceiveState;
+  private _firstTimestamp: number;
+  private _timestampRange: number;
+
+  constructor(readonly chainHash: Buffer, readonly peer: IMessageSender, readonly logger: ILogger) {
+    this._receiveState = PeerGossipReceiveState.Inactive;
+    this._firstTimestamp = uint32max;
+    this._timestampRange = 0;
+  }
+
+  public get receiveState() {
+    return this._receiveState;
+  }
+
+  public set receiveState(state: PeerGossipReceiveState) {
+    this._receiveState = state;
+    this.logger.debug("receive state changed to", state);
+  }
+
+  public get firstTimestamp(): number {
+    return this._firstTimestamp;
+  }
+
+  public get timestampRange(): number {
+    return this._timestampRange;
+  }
+
+  /**
+   * Deactivates gossip with the remote peer by sending a
+   * gossip_timestamp_filter message that disables broadcast. In particular this
+   * message will use a first_timestamp of uint32_max and a timestamp_range of
+   * 0 to prevent the remote peer from sending information.
+   */
+  public deactivate() {
+    this.logger.info("deactivating gossip");
+
+    // reset params
+    this._firstTimestamp = uint32max;
+    this._timestampRange = 0;
+
+    // send message
+    const msg = new GossipTimestampFilterMessage();
+    msg.chainHash = this.chainHash;
+    msg.firstTimestamp = uint32max;
+    msg.timestampRange = 0;
+    this.peer.sendMessage(msg);
+
+    // change state
+    this.receiveState = PeerGossipReceiveState.Inactive;
+  }
+
+  /**
+   * Activates gossip with the remote peer by sending a gossip_timestamp_filter
+   * message with the specified first timestamp and range. By default, this
+   * starts gossip with the current timestamp and uint32_max as the range.
+   * @param start
+   * @param range
+   */
+  public activate(start: number = Math.trunc(Date.now() / 1000), range = uint32max) {
+    this.logger.info("activating gossip for range %d to %d", start, range);
+
+    // set params
+    this._firstTimestamp = start;
+    this._timestampRange = range;
+
+    // send message
+    const msg = new GossipTimestampFilterMessage();
+    msg.chainHash = this.chainHash;
+    msg.firstTimestamp = start;
+    msg.timestampRange = range;
+    this.peer.sendMessage(msg);
+
+    // change state
+    this.receiveState = PeerGossipReceiveState.Receiving;
+  }
+}

--- a/packages/lntools-wire/lib/peer.ts
+++ b/packages/lntools-wire/lib/peer.ts
@@ -10,13 +10,15 @@ import { PeerOptions } from "./peer-options";
 import { PeerState } from "./peer-state";
 import { PingPongState } from "./pingpong-state";
 
-export declare interface IPeerMessageSender {
+export declare interface IMessageSender {
   sendMessage(msg: IWireMessage): void;
 }
 
-export declare interface IPeerMessageReceiver {
+export declare interface IMessageReceiver {
   on(event: "message", listener: (msg: IWireMessage) => void): this;
 }
+
+export type IMessageSenderReceiver = IMessageSender & IMessageReceiver;
 
 // tslint:disable-next-line: interface-name
 export declare interface Peer {
@@ -147,7 +149,7 @@ export declare interface Peer {
  *
  * @emits end emitted when the connection to the peer is ending.
  */
-export class Peer extends EventEmitter implements IPeerMessageSender, IPeerMessageReceiver {
+export class Peer extends EventEmitter implements IMessageSender, IMessageReceiver {
   public static states = PeerState;
 
   public state: PeerState = PeerState.Disconnected;


### PR DESCRIPTION
This code splits code in the PeerGossipSynchronizer to isolate the sync code from the update stream code controlled by gossip_timestamp_filter.  This is the first step towards #36 and #40 