### PR TITLE
Removes the rfc4648 pacakge from wire

### DIFF
--- a/packages/wire/__tests__/Base32.spec.ts
+++ b/packages/wire/__tests__/Base32.spec.ts
@@ -13,27 +13,27 @@ describe("Base32", () => {
         ];
 
         for (const test of tests) {
-            it(`${test[0]}`, () => {
+            it(`${test[0]} => ${test[1]}`, () => {
                 expect(Base32.encode(Buffer.from(test[0]))).to.equal(test[1]);
             });
         }
     });
 
-    // describe("decode()", () => {
-    //     const tests: Array<[string, string]> = [
-    //         ["", ""],
-    //         ["f", "MY======"],
-    //         ["fo", "MZXQ===="],
-    //         ["foo", "MZXW6==="],
-    //         ["foob", "MZXW6YQ="],
-    //         ["fooba", "MZXW6YTB"],
-    //         ["foobar", "MZXW6YTBOI======"],
-    //     ];
+    describe("decode()", () => {
+        const tests: Array<[string, string]> = [
+            ["", ""],
+            ["f", "MY======"],
+            ["fo", "MZXQ===="],
+            ["foo", "MZXW6==="],
+            ["foob", "MZXW6YQ="],
+            ["fooba", "MZXW6YTB"],
+            ["foobar", "MZXW6YTBOI======"],
+        ];
 
-    //     for (const test of tests) {
-    //         it(`${test[1]}`, () => {
-    //             expect(Base32.decode(test[1])).to.deep.equal(Buffer.from(test[0]));
-    //         });
-    //     }
-    // });
+        for (const test of tests) {
+            it(`${test[1]} => ${test[0]}`, () => {
+                expect(Base32.decode(test[1])).to.deep.equal(Buffer.from(test[0]));
+            });
+        }
+    });
 });

--- a/packages/wire/__tests__/Base32.spec.ts
+++ b/packages/wire/__tests__/Base32.spec.ts
@@ -2,37 +2,49 @@ import { expect } from "chai";
 import { Base32 } from "../lib/Base32";
 describe("Base32", () => {
     describe("encode()", () => {
-        const tests: Array<[string, string]> = [
-            ["", ""],
-            ["f", "MY======"],
-            ["fo", "MZXQ===="],
-            ["foo", "MZXW6==="],
-            ["foob", "MZXW6YQ="],
-            ["fooba", "MZXW6YTB"],
-            ["foobar", "MZXW6YTBOI======"],
+        const tests: Array<[Buffer, string]> = [
+            [Buffer.from(""), ""],
+            [Buffer.from("f"), "MY======"],
+            [Buffer.from("fo"), "MZXQ===="],
+            [Buffer.from("foo"), "MZXW6==="],
+            [Buffer.from("foob"), "MZXW6YQ="],
+            [Buffer.from("fooba"), "MZXW6YTB"],
+            [Buffer.from("foobar"), "MZXW6YTBOI======"],
+            [Buffer.from("00", "hex"), "AA======"],
+            [Buffer.from("01", "hex"), "AE======"],
+            [Buffer.from("0101", "hex"), "AEAQ===="],
+            [Buffer.from("010101", "hex"), "AEAQC==="],
+            [Buffer.from("01010101", "hex"), "AEAQCAI="],
+            [Buffer.from("0101010101", "hex"), "AEAQCAIB"],
         ];
 
         for (const test of tests) {
             it(`${test[0]} => ${test[1]}`, () => {
-                expect(Base32.encode(Buffer.from(test[0]))).to.equal(test[1]);
+                expect(Base32.encode(test[0])).to.equal(test[1]);
             });
         }
     });
 
     describe("decode()", () => {
-        const tests: Array<[string, string]> = [
-            ["", ""],
-            ["f", "MY======"],
-            ["fo", "MZXQ===="],
-            ["foo", "MZXW6==="],
-            ["foob", "MZXW6YQ="],
-            ["fooba", "MZXW6YTB"],
-            ["foobar", "MZXW6YTBOI======"],
+        const tests: Array<[Buffer, string]> = [
+            [Buffer.from(""), ""],
+            [Buffer.from("f"), "MY======"],
+            [Buffer.from("fo"), "MZXQ===="],
+            [Buffer.from("foo"), "MZXW6==="],
+            [Buffer.from("foob"), "MZXW6YQ="],
+            [Buffer.from("fooba"), "MZXW6YTB"],
+            [Buffer.from("foobar"), "MZXW6YTBOI======"],
+            [Buffer.from("00", "hex"), "AA======"],
+            [Buffer.from("01", "hex"), "AE======"],
+            [Buffer.from("0101", "hex"), "AEAQ===="],
+            [Buffer.from("010101", "hex"), "AEAQC==="],
+            [Buffer.from("01010101", "hex"), "AEAQCAI="],
+            [Buffer.from("0101010101", "hex"), "AEAQCAIB"],
         ];
 
         for (const test of tests) {
             it(`${test[1]} => ${test[0]}`, () => {
-                expect(Base32.decode(test[1])).to.deep.equal(Buffer.from(test[0]));
+                expect(Base32.decode(test[1])).to.deep.equal(test[0]);
             });
         }
     });

--- a/packages/wire/__tests__/Base32.spec.ts
+++ b/packages/wire/__tests__/Base32.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from "chai";
+import { Base32 } from "../lib/Base32";
+describe("Base32", () => {
+    describe("encode()", () => {
+        const tests: Array<[string, string]> = [
+            ["", ""],
+            ["f", "MY======"],
+            ["fo", "MZXQ===="],
+            ["foo", "MZXW6==="],
+            ["foob", "MZXW6YQ="],
+            ["fooba", "MZXW6YTB"],
+            ["foobar", "MZXW6YTBOI======"],
+        ];
+
+        for (const test of tests) {
+            it(`${test[0]}`, () => {
+                expect(Base32.encode(Buffer.from(test[0]))).to.equal(test[1]);
+            });
+        }
+    });
+
+    // describe("decode()", () => {
+    //     const tests: Array<[string, string]> = [
+    //         ["", ""],
+    //         ["f", "MY======"],
+    //         ["fo", "MZXQ===="],
+    //         ["foo", "MZXW6==="],
+    //         ["foob", "MZXW6YQ="],
+    //         ["fooba", "MZXW6YTB"],
+    //         ["foobar", "MZXW6YTBOI======"],
+    //     ];
+
+    //     for (const test of tests) {
+    //         it(`${test[1]}`, () => {
+    //             expect(Base32.decode(test[1])).to.deep.equal(Buffer.from(test[0]));
+    //         });
+    //     }
+    // });
+});

--- a/packages/wire/lib/Base32.ts
+++ b/packages/wire/lib/Base32.ts
@@ -7,54 +7,107 @@ export class Base32 {
      * @param buf
      */
     public static encode(buf: Buffer): string {
-        if (!buf.length) return "";
+        let result: string = "";
 
-        let result = "";
+        // if nothing, do nothing
+        if (!buf.length) return result;
 
-        // convert the original number to a bigint, which likely isn't the most
-        // efficient way to perform encodings, but the code is much more
-        // readable!
-        const original = BigInt("0x" + buf.toString("hex"));
+        // Captures the numeric value that we are operating with. This numeric
+        // value will allow us to perform simple bit operations and obtain an
+        // index value used for the encoding
+        let val: number = 0;
 
-        // Calculate the number of bits that we need to left shift our number
-        // by. Since our input data is 8 bits and our output is 5 bits, the LCM
-        // is 40 and we need to add padding bits until accordingly.
+        // Captures the number of bits that the current value represents. For
+        // example, a value of 00000 is a numeric value of 0 but has 5 bits.
+        let valBits: number = 0;
+
+        // Calculate sthe number of data bits for for the buffer. This value is
+        // used as input into calculating required number of padding bits.
         const dataBits = buf.length * 8;
+
+        // Calculates the padding bits. Since our input data is 8 bits and our
+        // output is 5 bits, the LCM is 40 and we need to add padding bits
+        // until we reach a bit length that is evenly divisible by the LCM.
         const padBits = dataBits % 40 === 0 ? 0 : 40 - (dataBits % 40);
 
-        // pad the orignal number with the required bits to make the number
-        // round to 40 bits
-        let num = original << BigInt(padBits);
+        // There are 5 possible scenarios for the padding calculation. This is
+        // based on observation and specified in RFC4648:
+        //  32 bits => 6 chars of 5 bit padding = 30, 2 bits of padding
+        //  24 bits => 4 chars of 5 bit padding = 20, 4 bits of padding
+        //  16 bits => 3 chars of 5 bit padding = 15, 1 bit of padding
+        //   8 bits => 1 char of 5 bit padding = 5, 3 bits of padding
+        switch (padBits) {
+            case 32:
+                result = Base32.pad.repeat(6);
+                valBits = 2;
+                break;
+            case 24:
+                result = Base32.pad.repeat(4);
+                valBits = 4;
+                break;
+            case 16:
+                result = Base32.pad.repeat(3);
+                valBits = 1;
+                break;
+            case 8:
+                result = Base32.pad;
+                valBits = 3;
+                break;
+        }
 
-        // creates a datamask with the lowest 5 bits set. We will use this
-        // value to read the lsbs from the number
+        // Create a bitmask for the lowest 5 bits set. We will use this value
+        // to read the LSBs from the value
         const mask = 0b11111; // 31
 
-        // at this point, the number may be larger than our original number and
-        // the least significant bits. Padding will be the least significant
-        // bits and the values will be the most significant bits
-        while (num > 0) {
-            // the least significant 5 bits will be our value. We mask these
-            // values and use that as the character index
-            const index = Number(num & BigInt(mask));
+        // We will iterate in reverse order. If we have a twos byte:
+        //   [0] = 0b11111111
+        //   [1] = 0b10101010
+        //
+        // We will need to pad 24 bits total, 20 of which can be applied via
+        // the pad character. The remaining 4 bits will be mixed with our data.
+        //
+        // So we start with 4 bits of padding which will be appended to the
+        // data:
+        //   0b0000:
+        //
+        // If we combined our two bytes and padding we end up with:
+        //   0b11111111101010100000
+        //
+        // This is 20 bits and can be evenly divided into four 5-bit words:
+        //     11111 11110 10101 00000
+        //
+        // Our algorithm will read these from right to left to minimize the
+        // number of bit shift operations that need to be performed.
+        for (let i = buf.length - 1; i >= 0; i--) {
+            // The first thing we do is read a byte from the input and we left
+            // shift it by the number of bits currently in the value.
+            // For example if our byte is 11111111 and the current value is
+            // made from 3 bits, our new value is 11111111000
+            const msbs = buf[i] << valBits;
 
-            // If the number is still larger than our original value than the
-            // current number has padding bits in it.
-            const isPadded = num > original;
+            // Now that we have shifted the byte we can simply combine the
+            // two values. For example if we have 11111111000 and 111, our new
+            // value is 11111111111. Finally increase the number of bits that
+            // the value is comprised from.
+            val |= msbs;
+            valBits += 8;
 
-            // when it is padded an there is no data, we encode the padding
-            // character
-            if (isPadded && index === 0) {
-                result = result + Base32.pad;
-            }
-            // otherwise the lowest 5 bits will be the index from 0-31 and we
-            // prepend the value since we are reading in reverse order
-            else {
+            // Read 5 bit chunks until we need to read another byte. Because we
+            // prepadded, the final byte will be evenly divided!
+            while (valBits >= 5) {
+                // Calculate the mask from the lowest 5 bits
+                const index = val & mask;
+
+                // Prepend the character from the index since we are reading
+                // data in reverse order. That is the last processed byte will
+                // end up being our first character.
                 result = Base32.alphabet[index] + result;
-            }
 
-            // remove the lowest 5 bits
-            num >>= BigInt(5);
+                // Remove the lower 5 bits from our value, shift the number of
+                // bits that the value is comprised of
+                val >>= 5;
+                valBits -= 5;
+            }
         }
 
         return result;
@@ -62,57 +115,108 @@ export class Base32 {
 
     /**
      * Decodes the buffer using padded Base32 defined in RFC 4648.
-     * @param val
+     * @param input
      */
-    public static decode(val: string): Buffer {
-        if (!val) return Buffer.alloc(0);
+    public static decode(input: string): Buffer {
+        if (!input) return Buffer.alloc(0);
 
-        // We will read each character and reconstruct the final number that
-        // was used to generate the string.
-        let num = BigInt(0);
+        const inBits = 5;
+        const outBits = 8;
+        const mask = (1 << outBits) - 1;
+        const words = [];
 
-        // Along the way we will count the number of padding characters we
-        // enounter, where each character represents 5 bits. We keep count of
-        // the padding chars found to help us calculate the padding bits at the
-        // end.
-        let paddingChars = 0;
+        // Captures the numeric value that we are operating with. This numeric
+        // value will allow us to perform simple bit operations and obtain an
+        // index value used for the encoding
+        let val: number = 0;
 
-        // Iterate each character in our input string
-        for (const char of val) {
-            // Obtain the index of the current character, or alternative note
-            // that we found a padding character
-            let index: number;
-            if (char === Base32.pad) {
-                index = 0;
-                paddingChars++;
-            } else {
-                index = Base32.alphabet.indexOf(char);
-            }
+        // Captures the number of bits that the current value represents. For
+        // example, a value of 00000 is a numeric value of 0 but has 5 bits.
+        let valBits: number = 0;
 
-            // Shift our number left by 5 bits and add the 5 bits for our index
-            // as the least significant bits
-            num <<= BigInt(5);
-            num += BigInt(index);
+        // We will use a persistent iterator so we can remove the padding and
+        // process words until there are zero words left to process. Start at
+        // the last character so we can first see how much padding exists.
+        let i: number = input.length - 1;
+
+        // Counts the number of padding characters that are at the end end of
+        // the encoding and decrement our persistent counter along the way
+        let padChars = 0;
+        while (input[i] === Base32.pad) {
+            padChars++;
+            i--;
         }
 
-        // Now we need to remove the padding bits. RFC4648 discusses that we
-        // will encounter a few different scenarios that allows us to calculate
-        // the total number of padded characters that were included in our
-        // original byte stream. For example, if ther are 6 padding characters
-        // ======, where each character is 5 bits, we have 30 bits of padding in
-        // the padding characters.  However, we need to decode to an event byte
-        // so we round up to 32 bits of padding. The same logic applies for each
-        // of the other padding characters.
-        let paddingBits: number = 0;
-        if (paddingChars === 6) paddingBits = 32;
-        else if (paddingChars === 4) paddingBits = 24;
-        else if (paddingChars === 3) paddingBits = 16;
-        else if (paddingChars === 1) paddingBits = 8;
+        // If there were padding characters then the last word contains some
+        // padding bits. We will use the number of padding characters to
+        // determine the number of padding bits and will process the value of
+        // the last word by shifting off the padding bits.
+        if (padChars) {
+            // Calcuate the padding bits given the padding characters. This is
+            // based on the fact that each word is 5-bits and we need to round
+            // up to the next multiple of 8. So 6 padding words = 30 bits, and
+            // we will have to 2 bits of padding in the preceding word.
+            let padBits = 0;
+            if (padChars === 6) padBits = 2;
+            else if (padChars === 4) padBits = 4;
+            else if (padChars === 3) padBits = 1;
+            else if (padChars === 1) padBits = 3;
 
-        // Right shift the padding bits to obtain our original number
-        num >>= BigInt(paddingBits);
+            // Next we extract the last value character and obtain the numeric
+            // value for the character in the alphabet.
+            const char = input[i];
+            const index = Base32.alphabet.indexOf(char);
+
+            // We right shift the value to remove the padding. Normally each
+            // word add 5 bits of value. In this case, we reduce the number of
+            // bits that make up the value by the number of padding bits.
+            val = index >> padBits;
+            valBits += inBits - padBits;
+
+            // Decrement the counter since the character has now been processed.
+            i--;
+        }
+
+        // We can now process the remaining characters
+        for (i; i >= 0; i--) {
+            // We extract the the character from the input and obtain the
+            // numeric value for the character in the alphabet.
+            const char = input[i];
+            const index: number = Base32.alphabet.indexOf(char);
+
+            // We shift the value to the left so that the word is placed as the
+            // most significant bits on the value. This mean that if our word is
+            // 0b11111 and the current value has 3 bits we end up with the value
+            // 0b11111000.
+            const msbs = index << valBits;
+
+            // Next we add the existing value to the new MSB version of our
+            // word. For example if the MSB is 0b11111000 and the current 3-bit
+            // value is 0b111 we end up with 0b11111111.
+            val |= msbs;
+
+            // Finally increase the number of bits that the value is comprised
+            // of by the size of the input word.
+            valBits += inBits;
+
+            // We can now process the value bits by iterating and obtaining the
+            // output bits
+            while (valBits >= outBits) {
+                // Obtain the lower bits that correspond to the output size
+                const word = val & mask;
+
+                // push the word onto the front of the output words. We do this
+                // because we are reading the characters in reverse order.
+                words.unshift(word);
+
+                // Finally we remove the lower 8 bits and decrement the size of
+                // the value bits.
+                val >>= outBits;
+                valBits -= outBits;
+            }
+        }
 
         // Return the Buffer with our original number
-        return Buffer.from(num.toString(16), "hex");
+        return Buffer.from(words);
     }
 }

--- a/packages/wire/lib/Base32.ts
+++ b/packages/wire/lib/Base32.ts
@@ -1,0 +1,63 @@
+export class Base32 {
+    public static alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    public static padding = "=";
+
+    public static encode(buf: Buffer): string {
+        if (!buf.length) return "";
+
+        let result = "";
+
+        // convert the original number to a bigint, which likely isn't the most
+        // efficient way to perform encodings, but the code is much more
+        // readable!
+        const original = BigInt("0x" + buf.toString("hex"));
+
+        // Calculate the number of bits that we need to left shift our number
+        // by. Since our input data is 8 bits and our output is 5 bits, the LCM
+        // is 40 and we need to add padding bits until accordingly.
+        const dataBits = buf.length * 8;
+        const padBits = dataBits % 40 === 0 ? 0 : 40 - (dataBits % 40);
+
+        // pad the orignal number with the required bits to make the number
+        // round to 40 bits
+        let num = original << BigInt(padBits);
+
+        // creates a datamask with the lowest 5 bits set. We will use this
+        // value to read the lsbs from the number
+        const mask = 0b11111; // 31
+
+        // at this point, the number may be larger than our original number and
+        // the least significant bits. Padding will be the least significant
+        // bits and the values will be the most significant bits
+        while (num > 0) {
+            // the least significant 5 bits will be our value. We mask these
+            // values and use that as the character index
+            const index = Number(num & BigInt(mask));
+
+            // If the number is still larger than our original value than the
+            // current number has padding bits in it.
+            const isPadded = num > original;
+
+            // when it is padded an there is no data, we encode the padding
+            // character
+            if (isPadded && index === 0) {
+                result = result + "=";
+            }
+            // otherwise the lowest 5 bits will be the index from 0-31 and we
+            // prepend the value since we are reading in reverse order
+            else {
+                result = Base32.alphabet[index] + result;
+            }
+
+            // remove the lowest 5 bits
+            num >>= BigInt(5);
+        }
+
+        return result;
+    }
+
+    public static decode(val: string): Buffer {
+        throw new Error();
+        // if (!val) return Buffer.alloc(0);
+    }
+}

--- a/packages/wire/lib/deserialize/address/torStringFromBuffer.ts
+++ b/packages/wire/lib/deserialize/address/torStringFromBuffer.ts
@@ -1,8 +1,8 @@
-import { base32 } from "rfc4648";
+import { Base32 } from "../../Base32";
 
 /**
  * Converts a Buffer into a TOR address including the .onion suffix
  */
 export function torStringFromBuffer(buffer: Buffer): string {
-    return base32.stringify(buffer).toLowerCase() + ".onion";
+    return Base32.encode(buffer).toLowerCase() + ".onion";
 }

--- a/packages/wire/lib/serialize/address/torStringToBuffer.ts
+++ b/packages/wire/lib/serialize/address/torStringToBuffer.ts
@@ -1,4 +1,4 @@
-import { base32 } from "rfc4648";
+import { Base32 } from "../../Base32";
 
 /**
  * Converts a Tor address in string notation into a Buffer
@@ -6,5 +6,5 @@ import { base32 } from "rfc4648";
 export function torStringToBuffer(host: string): Buffer {
     host = host.substr(0, host.indexOf("."));
     host = host.toUpperCase();
-    return Buffer.from(base32.parse(host));
+    return Base32.decode(host);
 }

--- a/packages/wire/package-lock.json
+++ b/packages/wire/package-lock.json
@@ -4,6 +4,43 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@lntools/bufio": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@lntools/bufio/-/bufio-0.9.0.tgz",
+      "integrity": "sha512-2UQG0SiF+UmvOcGYnxHocABl5cnIcGQACb0Sji1oR5Mzwu/JMeAXdLGPGb9eDyzsPBy0c8fLNexIKD1KGFGcxg=="
+    },
+    "@lntools/crypto": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@lntools/crypto/-/crypto-0.9.0.tgz",
+      "integrity": "sha512-XDrQQo0Q1rANvWapXJxSaedlK1GD5z9SS21YJXotRk8XmGPqO5rJXgCjydf/XHhBo+QT6TYKVrCK0Sh9vYjzZA==",
+      "requires": {
+        "secp256k1": "^3.6.2"
+      }
+    },
+    "@lntools/logger": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@lntools/logger/-/logger-0.9.0.tgz",
+      "integrity": "sha512-XC5OcvaWzc6OWmuVu7ghOn5lQ+1ysyf4xFs4iXtyum7eCShZix6kTVp/7OMCrSENeK+foM0lYp6LyagmCFRMhQ=="
+    },
+    "@lntools/noise": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@lntools/noise/-/noise-0.14.0.tgz",
+      "integrity": "sha512-1T6NhbHph94BfXy2zm8lktPGwPyrSixW3a1scBSsAR3SYP2bBTBzLd65cKDFmUN0w1PgA0TLEUKcilhnbSehkg==",
+      "requires": {
+        "@lntools/crypto": "^0.6.0",
+        "@lntools/logger": "^0.9.0"
+      },
+      "dependencies": {
+        "@lntools/crypto": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@lntools/crypto/-/crypto-0.6.0.tgz",
+          "integrity": "sha512-Q2rFqdXMtp+ng/aqSad3ZmsCFhR84EGw09aesT9jPCMm2a3XzaJMNtzUxQsIn5LnSgJvN8fkHPqok2aDoZPINg==",
+          "requires": {
+            "secp256k1": "^3.6.2"
+          }
+        }
+      }
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -12,20 +49,225 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "bn.js": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
+    "elliptic": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "node-addon-api": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
       "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
     },
-    "rfc4648": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.2.1.tgz",
-      "integrity": "sha512-WtA5N+n7sYVszB4K4ETLoIhREBH4Q/DHpoB/xK8pFPPAmd9TZGLWvj+UTnT3Le1r9va2uj9KZ/79nC7IfeT7vA=="
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "secp256k1": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.5.2",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "sse4_crc32": {
       "version": "6.0.1",
@@ -35,6 +277,19 @@
         "bindings": "^1.3.0",
         "node-addon-api": "^1.3.0"
       }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     }
   }
 }

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -29,7 +29,6 @@
     "@lntools/crypto": "^0.9.0",
     "@lntools/logger": "^0.9.0",
     "@lntools/noise": "^0.14.0",
-    "rfc4648": "^1.2.1",
     "sse4_crc32": "^6.0.1"
   },
   "gitHead": "f1db27c96af2dc1dd8cb3ca62952499afd8efc6c"


### PR DESCRIPTION
Closes #87

This package was being used for base32 encodings which are now found in the Base32.ts file.